### PR TITLE
Enable CSP headers & set the correct headers in config files

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,9 +33,9 @@ function initApp(options) {
     if(!app.conf.interface) { app.conf.interface = '0.0.0.0'; }
     if(!app.conf.compression_level) { app.conf.compression_level = 3; }
     if(app.conf.cors === undefined) { app.conf.cors = '*'; }
-    if(!app.conf.csp) {
+    if(app.conf.csp === undefined) {
         app.conf.csp =
-            "default-src 'self'; object-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";
+            "default-src 'self'; object-src 'none'; media-src *; img-src *; style-src * 'unsafe-inline'; script-src 'self' 'unsafe-inline'; frame-ancestors 'self'";
     }
 
     // set outgoing proxy
@@ -82,20 +82,19 @@ function initApp(options) {
     // set the CORS and CSP headers
     app.all('*', function(req, res, next) {
         if(app.conf.cors !== false) {
-            res.header('Access-Control-Allow-Origin', app.conf.cors);
-            res.header('Access-Control-Allow-Headers', 'Accept, X-Requested-With, Content-Type');
+            res.header('access-control-allow-origin', app.conf.cors);
+            res.header('access-control-allow-headers', 'accept, x-requested-with, content-type');
+            res.header('access-control-expose-headers', 'etag');
         }
-        res.header('X-XSS-Protection', '1; mode=block');
-        res.header('X-Content-Type-Options', 'nosniff');
-        res.header('X-Frame-Options', 'SAMEORIGIN');
-
-        // TODO: Uncomment once we figure out the needed CSP setting in config
-        // res.header('Content-Security-Policy', app.conf.csp);
-        // res.header('X-Content-Security-Policy', app.conf.csp);
-        // res.header('X-WebKit-CSP', app.conf.csp);
-
+        if(app.conf.csp !== false) {
+            res.header('x-xss-protection', '1; mode=block');
+            res.header('x-content-type-options', 'nosniff');
+            res.header('x-frame-options', 'SAMEORIGIN');
+            res.header('content-security-policy', app.conf.csp);
+            res.header('x-content-security-policy', app.conf.csp);
+            res.header('x-webkit-csp', app.conf.csp);
+        }
         sUtil.initAndLogRequest(req, app);
-
         next();
     });
 
@@ -198,4 +197,3 @@ module.exports = function(options) {
     .then(createServer);
 
 };
-

--- a/config.labs.yaml
+++ b/config.labs.yaml
@@ -32,9 +32,6 @@ services:
     conf:
       port: 6533
 
-      # TODO: This does not work, not sure of the exact reqs here, manually disabling for now
-      csp: default-src 'self'; script-src 'self' 'unsafe-inline';
-
       cache: public, s-maxage=36000, max-age=30
 
       sources:

--- a/config.ovh.yaml
+++ b/config.ovh.yaml
@@ -31,10 +31,7 @@ services:
     # per-service config
     conf:
       port: 6533
-#      Without this, allows for connections from everyone!
-#      interface: localhost
-
-      # TODO: This does not work, not sure of the exact reqs here, manually disabling for now
-      csp: default-src 'self'; script-src 'self' 'unsafe-inline';
-
+      # Uncomment to restrict connections to localhost only
+      # interface: localhost
+      
       sources: ../sources.yaml


### PR DESCRIPTION
So I think it would be awesome to eventually move inline scripts & styles from static/index.html into their own respective files... that way we would be able to use the default csp headers in app.js, not need to specify them in each config file, & it would be a little more secure. This also requires us to return different responses for things like errors, express naturally wraps messages like "Unknown source" in html with inline style. 

I was going to create an issue for this enhancement/ just work on it after this pull request...but if the end result sounds more appealing, I can revert these commits & just get straight to it. Thoughts? Cheers & enjoy the weekend!
