### PR TITLE
Use latest version of most dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 npm-debug.log
 vectors
 variables.yaml
+config.vagrant.yaml

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -63,8 +63,36 @@ services:
       # interface: localhost
 
       # Kartotherian variables and sources
-      variables: ../variables.yaml
-      sources: ../sources.yaml
+      variables: {}
+      sources: sources.dev.yaml
+
+      modules:
+      - "tilelive-bridge"
+      - "tilelive-vector"
+      - "@kartotherian/autogen"
+      - "@kartotherian/babel"
+      - "@kartotherian/cassandra"
+      - "@kartotherian/layermixer"
+      - "@kartotherian/overzoom"
+      - "@kartotherian/postgres"
+      - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-http"
+      - "tilejson"
+
+      requestHandlers:
+      - "@kartotherian/geoshapes"
+      - "@kartotherian/maki"
+      - "@kartotherian/snapshot"
+
+      geoshapes:
+        allowUserQueries: true
+        database: gis
+        host: localhost
+        lineTable: planet_osm_line
+        password: ''
+        polygonTable: planet_osm_polygon
+        table: planet_osm_polygon
+        user: ''
 
       # allowedDomains:
       #   http:

--- a/config.external.yaml
+++ b/config.external.yaml
@@ -57,6 +57,23 @@ services:
       variables: {}
       sources: sources.external.yaml
 
+      modules:
+      - "tilelive-bridge"
+      - "tilelive-vector"
+      - "@kartotherian/autogen"
+      - "@kartotherian/babel"
+      - "@kartotherian/cassandra"
+      - "@kartotherian/layermixer"
+      - "@kartotherian/overzoom"
+      - "@kartotherian/postgres"
+      - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-http"
+      - "tilejson"
+
+      requestHandlers:
+      - "@kartotherian/maki"
+      - "@kartotherian/snapshot"
+
       # allowedDomains:
       #   http:
       #     - localhost:8080

--- a/config.meddo.yaml
+++ b/config.meddo.yaml
@@ -102,6 +102,23 @@ services:
           xmlSetParams:
             source: {ref: babel}
 
+      modules:
+      - "tilelive-bridge"
+      - "tilelive-vector"
+      - "@kartotherian/autogen"
+      - "@kartotherian/babel"
+      - "@kartotherian/cassandra"
+      - "@kartotherian/layermixer"
+      - "@kartotherian/overzoom"
+      - "@kartotherian/postgres"
+      - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-http"
+      - "tilejson"
+
+      requestHandlers:
+      - "@kartotherian/maki"
+      - "@kartotherian/snapshot"
+
       # allowedDomains:
       #   http:
       #     - localhost:8080

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@kartotherian/osm-bright-style": "^2.1.4",
     "@kartotherian/geoshapes": "^0.0.13",
     "@kartotherian/maki": "^0.0.10",
-    "@kartotherian/snapshot": "^0.3.4"
+    "@kartotherian/snapshot": "kartotherian/snapshot#master"
   },
   "optionalDependencies": {
     "bunyan-prettystream": "*"

--- a/package.json
+++ b/package.json
@@ -30,20 +30,6 @@
   },
   "homepage": "https://github.com/kartotherian/kartotherian",
   "kartotherian": {
-    "registerSourceLibs": [
-      "tilelive-bridge",
-      "tilelive-vector",
-      "@kartotherian/autogen",
-      "@kartotherian/babel",
-      "@kartotherian/cassandra",
-      "@kartotherian/demultiplexer",
-      "@kartotherian/layermixer",
-      "@kartotherian/overzoom",
-      "@kartotherian/postgres",
-      "@kartotherian/substantial",
-      "@kartotherian/tilelive-http",
-      "tilejson"
-    ],
     "requestHandlers": [
       "@kartotherian/geoshapes",
       "@kartotherian/maki",
@@ -67,8 +53,8 @@
     "tilelive-bridge": "~2.3.1",
     "tilelive-vector": "~3.9.4",
     "tilejson": "^1.0.3",
-    "@kartotherian/core": "^0.0.23",
-    "@kartotherian/server": "^0.0.17",
+    "@kartotherian/core": "^0.1.1",
+    "@kartotherian/server": "^0.0.22",
     "@kartotherian/autogen": "^0.0.10",
     "@kartotherian/babel": "^0.0.7",
     "@kartotherian/cassandra": "^0.0.12",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@kartotherian/osm-bright-style": "^2.1.4",
     "@kartotherian/geoshapes": "^0.0.13",
     "@kartotherian/maki": "^0.0.10",
-    "@kartotherian/snapshot": "kartotherian/snapshot#master"
+    "@kartotherian/snapshot": "^0.3.5"
   },
   "optionalDependencies": {
     "bunyan-prettystream": "*"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@kartotherian/postgres": "^0.0.11",
     "@kartotherian/layermixer": "^0.0.8",
     "@kartotherian/overzoom": "^0.0.10",
-    "@kartotherian/substantial": "^0.0.8",
+    "@kartotherian/substantial": "^0.0.10",
     "@kartotherian/tilelive-http": "^0.12.1",
     "@kartotherian/osm-bright-source": "^0.0.5",
     "@kartotherian/osm-bright-style": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@kartotherian/server": "^0.0.22",
     "@kartotherian/autogen": "^0.0.10",
     "@kartotherian/babel": "^0.0.7",
-    "@kartotherian/cassandra": "^0.0.12",
+    "@kartotherian/cassandra": "^0.0.13",
     "@kartotherian/postgres": "^0.0.10",
     "@kartotherian/demultiplexer": "^0.0.10",
     "@kartotherian/layermixer": "^0.0.8",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@kartotherian/autogen": "^0.0.10",
     "@kartotherian/babel": "^0.0.7",
     "@kartotherian/cassandra": "^0.0.13",
-    "@kartotherian/postgres": "^0.0.10",
+    "@kartotherian/postgres": "^0.0.11",
     "@kartotherian/demultiplexer": "^0.0.10",
     "@kartotherian/layermixer": "^0.0.8",
     "@kartotherian/overzoom": "^0.0.10",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@kartotherian/cassandra": "^0.0.13",
     "@kartotherian/postgres": "^0.0.11",
     "@kartotherian/layermixer": "^0.0.8",
-    "@kartotherian/overzoom": "^0.0.10",
+    "@kartotherian/overzoom": "^0.0.16",
     "@kartotherian/substantial": "^0.0.10",
     "@kartotherian/tilelive-http": "^0.12.1",
     "@kartotherian/osm-bright-source": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,6 @@
     "url": "https://phabricator.wikimedia.org/tag/maps/"
   },
   "homepage": "https://github.com/kartotherian/kartotherian",
-  "kartotherian": {
-    "requestHandlers": [
-      "@kartotherian/geoshapes",
-      "@kartotherian/maki",
-      "@kartotherian/snapshot"
-    ]
-  },
   "dependencies": {
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@kartotherian/babel": "^0.0.7",
     "@kartotherian/cassandra": "^0.0.13",
     "@kartotherian/postgres": "^0.0.11",
-    "@kartotherian/demultiplexer": "^0.0.10",
     "@kartotherian/layermixer": "^0.0.8",
     "@kartotherian/overzoom": "^0.0.10",
     "@kartotherian/substantial": "^0.0.8",

--- a/routes/kartotherian.js
+++ b/routes/kartotherian.js
@@ -17,7 +17,7 @@ function startup(app) {
         return require('@kartotherian/server').init({
             core: core,
             app: app,
-            requestHandlers: core.loadNpmModules('requestHandlers')
+            requestHandlers: app.conf.requestHandlers.map( rh => require( rh ) )
         });
     }).return(); // avoid app.js's default route initialization
 }

--- a/routes/kartotherian.js
+++ b/routes/kartotherian.js
@@ -11,7 +11,7 @@ function startup(app) {
 
     return startup.bootstrap(app).then(function() {
         let sources = new core.Sources();
-        return sources.init(app.conf.variables, app.conf.sources);
+        return sources.init(app.conf);
     }).then(function (sources) {
         core.setSources(sources);
         return require('@kartotherian/server').init({

--- a/sources.dev.yaml
+++ b/sources.dev.yaml
@@ -17,7 +17,7 @@ v5:
     cp: 127.0.0.1
     repfactor: 1
     durablewrite: 0
-    createIfMissing: false
+    createIfMissing: true
 
 # View tiles as generated directly from the database. Don't view zoom0-5
 genview:


### PR DESCRIPTION
This PR updates kartotherian to use the latest version of most of it's kartotherian/* dependencies. Only (conscious) exception is kartotherian/err.

Deployed to maps-test*. Tested as much as I could with my limited knowledge of the domain and the application.