### PR TITLE
Add linting and make pass

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: 'kartotherian',
+  env: {
+    node: true,
+    es6: true,
+    browser: false,
+  },
+  rules: {
+    'comma-dangle': [
+      'error',
+      {
+        arrays: 'always-multiline',
+        objects: 'always-multiline',
+        imports: 'always-multiline',
+        exports: 'always-multiline',
+        // Dangling commas are unsupported in node
+        functions: 'never',
+      },
+    ],
+  },
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 sudo: false
 
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
   - "6"
-  - "node"
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libgif-dev

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,32 @@
+/* eslint-env node */
+module.exports = function Gruntfile(grunt) {
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-eslint');
+  grunt.loadNpmTasks('grunt-mocha-test');
+
+  grunt.initConfig({
+    eslint: {
+      code: {
+        src: [
+          '**/*.js',
+          '!node_modules/**',
+          '!vendor/**',
+          '!lib/**',
+          '!coverage/**',
+        ],
+      },
+    },
+    mochaTest: {
+      test: {
+        options: {
+          reporter: 'spec',
+        },
+        src: ['test/**/*.js'],
+      },
+    },
+  });
+
+  grunt.registerTask('lint', 'eslint');
+  grunt.registerTask('test', ['lint', 'mochaTest']);
+  grunt.registerTask('default', 'test');
+};

--- a/app.js
+++ b/app.js
@@ -1,15 +1,14 @@
-'use strict';
 
 
-var http = require('http');
-var BBPromise = require('bluebird');
-var express = require('express');
-var compression = require('compression');
-var bodyParser = require('body-parser');
-var fs = BBPromise.promisifyAll(require('fs'));
-var sUtil = require('./lib/util');
-var packageInfo = require('./package.json');
-var yaml = require('js-yaml');
+const http = require('http');
+const BBPromise = require('bluebird');
+const express = require('express');
+const compression = require('compression');
+const bodyParser = require('body-parser');
+const fs = BBPromise.promisifyAll(require('fs'));
+const sUtil = require('./lib/util');
+const packageInfo = require('./package.json');
+const yaml = require('js-yaml');
 
 
 /**
@@ -18,110 +17,106 @@ var yaml = require('js-yaml');
  * @return {bluebird} the promise resolving to the app object
  */
 function initApp(options) {
+  // the main application object
+  const app = express();
 
-    // the main application object
-    var app = express();
+  // get the options and make them available in the app
+  app.logger = options.logger; // the logging device
+  app.metrics = options.metrics; // the metrics
+  app.conf = options.config; // this app's config options
+  app.info = packageInfo; // this app's package info
 
-    // get the options and make them available in the app
-    app.logger = options.logger;    // the logging device
-    app.metrics = options.metrics;  // the metrics
-    app.conf = options.config;      // this app's config options
-    app.info = packageInfo;         // this app's package info
-
-    // ensure some sane defaults
-    if(!app.conf.port) { app.conf.port = 8888; }
-    if(!app.conf.interface) { app.conf.interface = '0.0.0.0'; }
-    if(app.conf.compression_level === undefined) { app.conf.compression_level = 3; }
-    if(app.conf.cors === undefined) { app.conf.cors = '*'; }
-    if(app.conf.csp === undefined) {
-        app.conf.csp =
+  // ensure some sane defaults
+  if (!app.conf.port) { app.conf.port = 8888; }
+  if (!app.conf.interface) { app.conf.interface = '0.0.0.0'; }
+  if (app.conf.compression_level === undefined) { app.conf.compression_level = 3; }
+  if (app.conf.cors === undefined) { app.conf.cors = '*'; }
+  if (app.conf.csp === undefined) {
+    app.conf.csp =
             "default-src 'self'; object-src 'none'; media-src 'none'; style-src 'self'; script-src 'self'; frame-ancestors 'self'";
-    }
+  }
 
-    // set outgoing proxy
-    if(app.conf.proxy) {
-        process.env.HTTP_PROXY = app.conf.proxy;
-        // if there is a list of domains which should
-        // not be proxied, set it
-        if(app.conf.no_proxy_list) {
-            if(Array.isArray(app.conf.no_proxy_list)) {
-                process.env.NO_PROXY = app.conf.no_proxy_list.join(',');
-            } else {
-                process.env.NO_PROXY = app.conf.no_proxy_list;
-            }
-        }
+  // set outgoing proxy
+  if (app.conf.proxy) {
+    process.env.HTTP_PROXY = app.conf.proxy;
+    // if there is a list of domains which should
+    // not be proxied, set it
+    if (app.conf.no_proxy_list) {
+      if (Array.isArray(app.conf.no_proxy_list)) {
+        process.env.NO_PROXY = app.conf.no_proxy_list.join(',');
+      } else {
+        process.env.NO_PROXY = app.conf.no_proxy_list;
+      }
     }
+  }
 
-    // set up header whitelisting for logging
-    if(!app.conf.log_header_whitelist) {
-        app.conf.log_header_whitelist = [
-                'cache-control', 'content-type', 'content-length', 'if-match',
-                'user-agent', 'x-request-id'
-        ];
-    }
-    app.conf.log_header_whitelist = new RegExp('^(?:' + app.conf.log_header_whitelist.map(function(item) {
-        return item.trim();
-    }).join('|') + ')$', 'i');
+  // set up header whitelisting for logging
+  if (!app.conf.log_header_whitelist) {
+    app.conf.log_header_whitelist = [
+      'cache-control', 'content-type', 'content-length', 'if-match',
+      'user-agent', 'x-request-id',
+    ];
+  }
+  app.conf.log_header_whitelist = new RegExp(`^(?:${app.conf.log_header_whitelist.map(item => item.trim()).join('|')})$`, 'i');
 
-    // set up the spec
-    if(!app.conf.spec) {
-        app.conf.spec = __dirname + '/spec.yaml';
+  // set up the spec
+  if (!app.conf.spec) {
+    app.conf.spec = `${__dirname}/spec.yaml`;
+  }
+  if (app.conf.spec.constructor !== Object) {
+    try {
+      app.conf.spec = yaml.safeLoad(fs.readFileSync(app.conf.spec));
+    } catch (e) {
+      app.logger.log('warn/spec', `Could not load the spec: ${e}`);
+      app.conf.spec = {};
     }
-    if(app.conf.spec.constructor !== Object) {
-        try {
-            app.conf.spec = yaml.safeLoad(fs.readFileSync(app.conf.spec));
-        } catch(e) {
-            app.logger.log('warn/spec', 'Could not load the spec: ' + e);
-            app.conf.spec = {};
-        }
-    }
-    if(!app.conf.spec.swagger) {
-        app.conf.spec.swagger = '2.0';
-    }
-    if(!app.conf.spec.info) {
-        app.conf.spec.info = {
-            version: app.info.version,
-            title: app.info.name,
-            description: app.info.description
-        };
-    }
-    app.conf.spec.info.version = app.info.version;
-    if(!app.conf.spec.paths) {
-        app.conf.spec.paths = {};
-    }
+  }
+  if (!app.conf.spec.swagger) {
+    app.conf.spec.swagger = '2.0';
+  }
+  if (!app.conf.spec.info) {
+    app.conf.spec.info = {
+      version: app.info.version,
+      title: app.info.name,
+      description: app.info.description,
+    };
+  }
+  app.conf.spec.info.version = app.info.version;
+  if (!app.conf.spec.paths) {
+    app.conf.spec.paths = {};
+  }
 
-    // set the CORS and CSP headers
-    app.all('*', function(req, res, next) {
-        if(app.conf.cors !== false) {
-            res.header('access-control-allow-origin', app.conf.cors);
-            res.header('access-control-allow-headers', 'accept, x-requested-with, content-type');
-            res.header('access-control-expose-headers', 'etag');
-        }
-        if(app.conf.csp !== false) {
-            res.header('x-xss-protection', '1; mode=block');
-            res.header('x-content-type-options', 'nosniff');
-            res.header('x-frame-options', 'SAMEORIGIN');
-            res.header('content-security-policy', app.conf.csp);
-            res.header('x-content-security-policy', app.conf.csp);
-            res.header('x-webkit-csp', app.conf.csp);
-        }
-        sUtil.initAndLogRequest(req, app);
-        next();
-    });
+  // set the CORS and CSP headers
+  app.all('*', (req, res, next) => {
+    if (app.conf.cors !== false) {
+      res.header('access-control-allow-origin', app.conf.cors);
+      res.header('access-control-allow-headers', 'accept, x-requested-with, content-type');
+      res.header('access-control-expose-headers', 'etag');
+    }
+    if (app.conf.csp !== false) {
+      res.header('x-xss-protection', '1; mode=block');
+      res.header('x-content-type-options', 'nosniff');
+      res.header('x-frame-options', 'SAMEORIGIN');
+      res.header('content-security-policy', app.conf.csp);
+      res.header('x-content-security-policy', app.conf.csp);
+      res.header('x-webkit-csp', app.conf.csp);
+    }
+    sUtil.initAndLogRequest(req, app);
+    next();
+  });
 
-    // disable the X-Powered-By header
-    app.set('x-powered-by', false);
-    // disable the ETag header - users should provide them!
-    app.set('etag', false);
-    // enable compression
-    app.use(compression({level: app.conf.compression_level}));
-    // use the JSON body parser
-    app.use(bodyParser.json());
-    // use the application/x-www-form-urlencoded parser
-    app.use(bodyParser.urlencoded({extended: true}));
+  // disable the X-Powered-By header
+  app.set('x-powered-by', false);
+  // disable the ETag header - users should provide them!
+  app.set('etag', false);
+  // enable compression
+  app.use(compression({ level: app.conf.compression_level }));
+  // use the JSON body parser
+  app.use(bodyParser.json());
+  // use the application/x-www-form-urlencoded parser
+  app.use(bodyParser.urlencoded({ extended: true }));
 
-    return BBPromise.resolve(app);
-
+  return BBPromise.resolve(app);
 }
 
 
@@ -130,44 +125,44 @@ function initApp(options) {
  * @param {Application} app the application object to load routes into
  * @returns {bluebird} a promise resolving to the app object
  */
-function loadRoutes (app) {
-
-    // get the list of files in routes/
-    return fs.readdirAsync(__dirname + '/routes').map(function(fname) {
-        return BBPromise.try(function() {
-            // ... and then load each route
-            // but only if it's a js file
-            if(!/\.js$/.test(fname)) {
-                return undefined;
-            }
-            // import the route file
-            var route = require(__dirname + '/routes/' + fname);
-            return route(app);
-        }).then(function(route) {
-            if(route === undefined) {
-                return undefined;
-            }
-            // check that the route exports the object we need
-            if(route.constructor !== Object || !route.path || !route.router || !(route.api_version || route.skip_domain)) {
-                throw new TypeError('routes/' + fname + ' does not export the correct object!');
-            }
-            // wrap the route handlers with Promise.try() blocks
-            sUtil.wrapRouteHandlers(route.router);
-            // determine the path prefix
-            var prefix = '';
-            if(!route.skip_domain) {
-                prefix = '/:domain/v' + route.api_version;
-            }
-            // all good, use that route
-            app.use(prefix + route.path, route.router);
-        });
-    }).then(function () {
-        // catch errors
-        sUtil.setErrorHandler(app);
-        // route loading is now complete, return the app object
-        return BBPromise.resolve(app);
-    });
-
+function loadRoutes(app) {
+  // get the list of files in routes/
+  return fs.readdirAsync(`${__dirname}/routes`).map(fname => BBPromise.try(() => {
+    // ... and then load each route
+    // but only if it's a js file
+    if (!/\.js$/.test(fname)) {
+      return undefined;
+    }
+    // import the route file
+    const route = require(`${__dirname}/routes/${fname}`); // eslint-disable-line global-require,import/no-dynamic-require
+    return route(app);
+  }).then((route) => {
+    if (route === undefined) {
+      return;
+    }
+    // check that the route exports the object we need
+    if (
+      route.constructor !== Object ||
+      !route.path || !route.router ||
+      !(route.api_version || route.skip_domain)
+    ) {
+      throw new TypeError(`routes/${fname} does not export the correct object!`);
+    }
+    // wrap the route handlers with Promise.try() blocks
+    sUtil.wrapRouteHandlers(route.router);
+    // determine the path prefix
+    let prefix = '';
+    if (!route.skip_domain) {
+      prefix = `/:domain/v${route.api_version}`;
+    }
+    // all good, use that route
+    app.use(prefix + route.path, route.router);
+  })).then(() => {
+    // catch errors
+    sUtil.setErrorHandler(app);
+    // route loading is now complete, return the app object
+    return BBPromise.resolve(app);
+  });
 }
 
 
@@ -177,23 +172,23 @@ function loadRoutes (app) {
  * @returns {bluebird} a promise creating the web server
  */
 function createServer(app) {
-
-    // return a promise which creates an HTTP server,
-    // attaches the app to it, and starts accepting
-    // incoming client requests
-    var server;
-    return new BBPromise(function (resolve) {
-        server = http.createServer(app).listen(
-            app.conf.port,
-            app.conf.interface,
-            resolve
-        );
-    }).then(function () {
-        app.logger.log('info',
-            'Worker ' + process.pid + ' listening on ' + app.conf.interface + ':' + app.conf.port);
-        return server;
-    });
-
+  // return a promise which creates an HTTP server,
+  // attaches the app to it, and starts accepting
+  // incoming client requests
+  let server;
+  return new BBPromise(((resolve) => {
+    server = http.createServer(app).listen(
+      app.conf.port,
+      app.conf.interface,
+      resolve
+    );
+  })).then(() => {
+    app.logger.log(
+      'info',
+      `Worker ${process.pid} listening on ${app.conf.interface}:${app.conf.port}`
+    );
+    return server;
+  });
 }
 
 
@@ -203,10 +198,8 @@ function createServer(app) {
  * service-runner and starts an HTTP server, attaching the application
  * object to it.
  */
-module.exports = function(options) {
-
-    return initApp(options)
+module.exports = function entry(options) {
+  return initApp(options)
     .then(loadRoutes)
     .then(createServer);
-
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./app.js",
   "scripts": {
     "start": "service-runner",
-    "test": "mocha",
+    "test": "grunt test",
     "docker-start": "service-runner docker-start",
     "docker-test": "service-runner docker-test",
     "coverage": "istanbul cover _mocha -- -R spec"
@@ -66,9 +66,15 @@
     "bunyan-prettystream": "*"
   },
   "devDependencies": {
+    "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-config-kartotherian": "^0.0.4",
     "extend": "^3.0.0",
+    "grunt": "^1.0.2",
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-eslint": "^20.1.0",
+    "grunt-mocha-test": "^0.13.3",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
+    "mocha": "^5.0.4",
     "mocha-jshint": "^2.3.1",
     "mocha-lcov-reporter": "^1.3.0",
     "swagger-router": "^0.5.6"

--- a/routes/info.js
+++ b/routes/info.js
@@ -1,34 +1,29 @@
-'use strict';
-
-
-var sUtil = require('../lib/util');
+const sUtil = require('../lib/util');
 
 
 /**
  * The main router object
  */
-var router = sUtil.router();
+const router = sUtil.router();
 
 /**
  * The main application object reported when this module is require()d
  */
-var app;
+let app;
 
 
 /**
  * GET /
  * Gets some basic info about this service
  */
-router.get('/', function(req, res) {
-
-    // simple sync return
-    res.json({
-        name: app.info.name,
-        version: app.info.version,
-        description: app.info.description,
-        home: app.info.homepage
-    });
-
+router.get('/', (req, res) => {
+  // simple sync return
+  res.json({
+    name: app.info.name,
+    version: app.info.version,
+    description: app.info.description,
+    home: app.info.homepage,
+  });
 });
 
 
@@ -36,11 +31,9 @@ router.get('/', function(req, res) {
  * GET /name
  * Gets the service's name as defined in package.json
  */
-router.get('/name', function(req, res) {
-
-    // simple return
-    res.json({ name: app.info.name });
-
+router.get('/name', (req, res) => {
+  // simple return
+  res.json({ name: app.info.name });
 });
 
 
@@ -48,11 +41,9 @@ router.get('/name', function(req, res) {
  * GET /version
  * Gets the service's version as defined in package.json
  */
-router.get('/version', function(req, res) {
-
-    // simple return
-    res.json({ version: app.info.version });
-
+router.get('/version', (req, res) => {
+  // simple return
+  res.json({ version: app.info.version });
 });
 
 
@@ -61,30 +52,24 @@ router.get('/version', function(req, res) {
  * Redirects to the service's home page if one is given,
  * returns a 404 otherwise
  */
-router.all('/home', function(req, res) {
-
-    var home = app.info.homepage;
-    if(home && /^http/.test(home)) {
-        // we have a home page URI defined, so send it
-        res.redirect(301, home);
-        return;
-    } else {
-        // no URI defined for the home page, error out
-        res.status(404).end('No home page URL defined for ' + app.info.name);
-    }
-
+router.all('/home', (req, res) => {
+  const home = app.info.homepage;
+  if (home && /^http/.test(home)) {
+    // we have a home page URI defined, so send it
+    res.redirect(301, home);
+  } else {
+    // no URI defined for the home page, error out
+    res.status(404).end(`No home page URL defined for ${app.info.name}`);
+  }
 });
 
 
-module.exports = function(appObj) {
+module.exports = function info(appObj) {
+  app = appObj;
 
-    app = appObj;
-
-    return {
-        path: '/_info',
-        skip_domain: true,
-        router: router
-    };
-
+  return {
+    path: '/_info',
+    skip_domain: true,
+    router,
+  };
 };
-

--- a/routes/kartotherian.js
+++ b/routes/kartotherian.js
@@ -1,36 +1,36 @@
-'use strict';
 
-let pathLib = require('path'),
-    Promise = require('bluebird'),
-    core = require('@kartotherian/core'),
-    info = require('../package.json');
 
-module.exports = startup;
+const pathLib = require('path');
+const Promise = require('bluebird');
+const core = require('@kartotherian/core');
+const info = require('../package.json');
+const server = require('@kartotherian/server');
 
 function startup(app) {
-
-    return startup.bootstrap(app).then(function() {
-        let sources = new core.Sources();
-        return sources.init(app.conf);
-    }).then(function (sources) {
-        core.setSources(sources);
-        return require('@kartotherian/server').init({
-            core: core,
-            app: app,
-            requestHandlers: app.conf.requestHandlers.map( rh => require( rh ) )
-        });
-    }).return(); // avoid app.js's default route initialization
+  return startup.bootstrap(app).then(() => {
+    const sources = new core.Sources();
+    return sources.init(app.conf);
+  }).then((sources) => {
+    core.setSources(sources);
+    return server.init({
+      core,
+      app,
+      // eslint-disable-next-line global-require,import/no-dynamic-require
+      requestHandlers: app.conf.requestHandlers.map(rh => require(rh)),
+    });
+  }).return(); // avoid app.js's default route initialization
 }
 
 startup.bootstrap = function bootstrap(app) {
-    return Promise.try(function () {
-        core.init(app, info.kartotherian, pathLib.resolve(__dirname, '..'),
-            function (module) {
-                return require(module);
-            },
-            function (module) {
-                return require.resolve(module);
-            }
-        );
-    });
+  return Promise.try(() => {
+    core.init(
+      app, info.kartotherian, pathLib.resolve(__dirname, '..'),
+      // eslint-disable-next-line global-require,import/no-dynamic-require
+      module => require(module),
+      // eslint-disable-next-line global-require,import/no-dynamic-require
+      module => require.resolve(module)
+    );
+  });
 };
+
+module.exports = startup;

--- a/routes/root.js
+++ b/routes/root.js
@@ -1,31 +1,28 @@
-'use strict';
 
 
-var sUtil = require('../lib/util');
+const sUtil = require('../lib/util');
 
 
 /**
  * The main router object
  */
-var router = sUtil.router();
+const router = sUtil.router();
 
 /**
  * The main application object reported when this module is require()d
  */
-var app;
+let app;
 
 
 /**
  * GET /robots.txt
  * Instructs robots no indexing should occur on this domain.
  */
-router.get('/robots.txt', function(req, res) {
-
-    res.set({
-        'User-agent': '*',
-        'Disallow': '/'
-    }).end();
-
+router.get('/robots.txt', (req, res) => {
+  res.set({
+    'User-agent': '*',
+    Disallow: '/',
+  }).end();
 });
 
 
@@ -34,26 +31,21 @@ router.get('/robots.txt', function(req, res) {
  * Main entry point. Currently it only responds if the spec query
  * parameter is given, otherwise lets the next middleware handle it
  */
-router.get('/', function(req, res, next) {
-
-    if(!(req.query || {}).hasOwnProperty('spec')) {
-        next();
-    } else {
-        res.json(app.conf.spec);
-    }
-
+router.get('/', (req, res, next) => {
+  if (!Object.prototype.hasOwnProperty.call((req.query || {}), 'spec')) {
+    next();
+  } else {
+    res.json(app.conf.spec);
+  }
 });
 
 
-module.exports = function(appObj) {
+module.exports = function root(appObj) {
+  app = appObj;
 
-    app = appObj;
-
-    return {
-        path: '/',
-        skip_domain: true,
-        router: router
-    };
-
+  return {
+    path: '/',
+    skip_domain: true,
+    router,
+  };
 };
-

--- a/server.js
+++ b/server.js
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 
-'use strict';
-
 // Service entry point. Try node server --help for commandline options.
 
 // Start the service by running service-runner, which in turn loads the config
 // (config.yaml by default, specify other path with -c). It requires the
 // module(s) specified in the config 'services' section (app.js in this
 // example).
-var ServiceRunner = require('service-runner');
-return new ServiceRunner().run();
+const ServiceRunner = require('service-runner');
+
+new ServiceRunner().run();

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: '../.eslintrc.js',
+  rules: {
+    // It is okay to import devDependencies in tests.
+    'import/no-extraneous-dependencies': [2, { devDependencies: true }],
+  },
+};

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -1,80 +1,73 @@
+/* global describe it before */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
+const preq = require('preq');
+const assert = require('../../utils/assert.js');
+const server = require('../../utils/server.js');
 
-var preq   = require('preq');
-var assert = require('../../utils/assert.js');
-var server = require('../../utils/server.js');
 
+describe('express app', function test() {
+  this.timeout(20000);
 
-describe('express app', function() {
+  before(() => server.start());
 
-    this.timeout(20000);
+  it('should get robots.txt', () => preq.get({
+    uri: `${server.config.uri}robots.txt`,
+  }).then((res) => {
+    assert.deepEqual(res.status, 200);
+    assert.deepEqual(res.headers.disallow, '/');
+  }));
 
-    before(function () { return server.start(); });
-
-    it('should get robots.txt', function() {
-        return preq.get({
-            uri: server.config.uri + 'robots.txt'
-        }).then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['disallow'], '/');
-        });
+  it('should set CORS headers', () => {
+    if (server.config.service.conf.cors === false) {
+      return true;
+    }
+    return preq.get({
+      uri: `${server.config.uri}robots.txt`,
+    }).then((res) => {
+      assert.deepEqual(res.status, 200);
+      assert.deepEqual(res.headers['access-control-allow-origin'], '*');
+      assert.deepEqual(!!res.headers['access-control-allow-headers'], true);
+      assert.deepEqual(!!res.headers['access-control-expose-headers'], true);
     });
+  });
 
-    it('should set CORS headers', function() {
-        if(server.config.service.conf.cors === false) {
-            return true;
-        }
-        return preq.get({
-            uri: server.config.uri + 'robots.txt'
-        }).then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['access-control-allow-origin'], '*');
-            assert.deepEqual(!!res.headers['access-control-allow-headers'], true);
-            assert.deepEqual(!!res.headers['access-control-expose-headers'], true);
-        });
+  it('should set CSP headers', () => {
+    if (server.config.service.conf.csp === false) {
+      return true;
+    }
+    return preq.get({
+      uri: `${server.config.uri}robots.txt`,
+    }).then((res) => {
+      assert.deepEqual(res.status, 200);
+      assert.deepEqual(res.headers['x-xss-protection'], '1; mode=block');
+      assert.deepEqual(res.headers['x-content-type-options'], 'nosniff');
+      assert.deepEqual(res.headers['x-frame-options'], 'SAMEORIGIN');
+      assert.deepEqual(res.headers['content-security-policy'], 'default-src');
+      assert.deepEqual(res.headers['x-content-security-policy'], 'default-src');
+      assert.deepEqual(res.headers['x-webkit-csp'], 'default-src');
     });
+  });
 
-    it('should set CSP headers', function() {
-        if(server.config.service.conf.csp === false) {
-            return true;
-        }
-        return preq.get({
-            uri: server.config.uri + 'robots.txt'
-        }).then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['x-xss-protection'], '1; mode=block');
-            assert.deepEqual(res.headers['x-content-type-options'], 'nosniff');
-            assert.deepEqual(res.headers['x-frame-options'], 'SAMEORIGIN');
-            assert.deepEqual(res.headers['content-security-policy'], 'default-src');
-            assert.deepEqual(res.headers['x-content-security-policy'], 'default-src');
-            assert.deepEqual(res.headers['x-webkit-csp'], 'default-src');
-        });
-    });
+  it.skip('should get static content gzipped', () => preq.get({
+    uri: `${server.config.uri}static/index.html`,
+    headers: {
+      'accept-encoding': 'gzip, deflate',
+    },
+  }).then((res) => {
+    // check that the response is gzip-ed
+    assert.deepEqual(res.headers['content-encoding'], 'gzip', 'Expected gzipped contents!');
+  }));
 
-    it.skip('should get static content gzipped', function() {
-        return preq.get({
-            uri: server.config.uri + 'static/index.html',
-            headers: {
-                'accept-encoding': 'gzip, deflate'
-            }
-        }).then(function(res) {
-            // check that the response is gzip-ed
-            assert.deepEqual(res.headers['content-encoding'], 'gzip', 'Expected gzipped contents!');
-        });
-    });
-
-    it('should get static content uncompressed', function() {
-        return preq.get({
-            uri: server.config.uri + 'static/index.html',
-            headers: {
-                'accept-encoding': ''
-            }
-        }).then(function(res) {
-            // check that the response is gzip-ed
-            assert.deepEqual(res.headers['content-encoding'], undefined, 'Did not expect gzipped contents!');
-        });
-    });
-
+  it('should get static content uncompressed', () => preq.get({
+    uri: `${server.config.uri}static/index.html`,
+    headers: {
+      'accept-encoding': '',
+    },
+  }).then((res) => {
+    // check that the response is gzip-ed
+    assert.deepEqual(res.headers['content-encoding'], undefined, 'Did not expect gzipped contents!');
+  }));
 });
-

--- a/test/features/app/spec.js
+++ b/test/features/app/spec.js
@@ -1,285 +1,273 @@
+/* global describe it before */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
-
-var preq   = require('preq');
-var assert = require('../../utils/assert.js');
-var server = require('../../utils/server.js');
-var URI    = require('swagger-router').URI;
-var yaml   = require('js-yaml');
-var fs     = require('fs');
+const preq = require('preq');
+const assert = require('../../utils/assert.js');
+const server = require('../../utils/server.js');
+const { URI } = require('swagger-router');
+const yaml = require('js-yaml');
+const fs = require('fs');
 
 
 function staticSpecLoad() {
+  let spec;
+  const myService = server.config.conf.services[server.config.conf.services.length - 1].conf;
+  const specPath = `${__dirname}/../../../${myService.spec ? myService.spec : 'spec.yaml'}`;
 
-    var spec;
-    var myService = server.config.conf.services[server.config.conf.services.length - 1].conf;
-    var specPath = __dirname + '/../../../' + (myService.spec ? myService.spec : 'spec.yaml');
+  try {
+    spec = yaml.safeLoad(fs.readFileSync(specPath));
+  } catch (e) {
+    // this error will be detected later, so ignore it
+    spec = { paths: {}, 'x-default-params': {} };
+  }
 
-    try {
-        spec = yaml.safeLoad(fs.readFileSync(specPath));
-    } catch(e) {
-        // this error will be detected later, so ignore it
-        spec = {paths: {}, 'x-default-params': {}};
-    }
-
-    return spec;
-
+  return spec;
 }
 
 
 function validateExamples(pathStr, defParams, mSpec) {
+  const uri = new URI(pathStr, {}, true);
 
-    var uri = new URI(pathStr, {}, true);
-
-    if(!mSpec) {
-        try {
-            uri.expand(defParams);
-            return true;
-        } catch(e) {
-            throw new Error('Missing parameter for route ' + pathStr + ' : ' + e.message);
-        }
+  if (!mSpec) {
+    try {
+      uri.expand(defParams);
+      return true;
+    } catch (e) {
+      throw new Error(`Missing parameter for route ${pathStr} : ${e.message}`);
     }
+  }
 
-    if(!Array.isArray(mSpec)) {
-        throw new Error('Route ' + pathStr + ' : x-amples must be an array!');
+  if (!Array.isArray(mSpec)) {
+    throw new Error(`Route ${pathStr} : x-amples must be an array!`);
+  }
+
+  mSpec.forEach((ex, idx) => {
+    const request = ex.request || {};
+    if (!ex.title) {
+      throw new Error(`Route ${pathStr}, example ${idx}: title missing!`);
     }
+    try {
+      uri.expand(Object.assign({}, defParams, request.params || {}));
+    } catch (e) {
+      throw new Error(`Route ${pathStr}, example ${idx} (${ex.title}): missing parameter: ${e.message}`);
+    }
+  });
 
-    mSpec.forEach(function(ex, idx) {
-        if(!ex.title) {
-            throw new Error('Route ' + pathStr + ', example ' + idx + ': title missing!');
-        }
-        ex.request = ex.request || {};
-        try {
-            uri.expand(Object.assign({}, defParams, ex.request.params || {}));
-        } catch(e) {
-            throw new Error('Route ' + pathStr + ', example ' + idx + ' (' + ex.title + '): missing parameter: ' + e.message);
-        }
-    });
-
-    return true;
-
+  return true;
 }
 
 
 function constructTestCase(title, path, method, request, response) {
-
-    return {
-        title: title,
-        request: {
-            uri: server.config.uri + (path[0] === '/' ? path.substr(1) : path),
-            method: method,
-            headers: request.headers || {},
-            query: request.query,
-            body: request.body,
-            followRedirect: false
-        },
-        response: {
-            status: response.status || 200,
-            headers: response.headers || {},
-            body: response.body
-        }
-    };
-
+  return {
+    title,
+    request: {
+      uri: server.config.uri + (path[0] === '/' ? path.substr(1) : path),
+      method,
+      headers: request.headers || {},
+      query: request.query,
+      body: request.body,
+      followRedirect: false,
+    },
+    response: {
+      status: response.status || 200,
+      headers: response.headers || {},
+      body: response.body,
+    },
+  };
 }
 
 
 function constructTests(paths, defParams) {
+  const ret = [];
 
-    var ret = [];
+  Object.keys(paths).forEach((pathStr) => {
+    Object.keys(paths[pathStr]).forEach((method) => {
+      const p = paths[pathStr][method];
+      const uri = new URI(pathStr, {}, true);
 
-    Object.keys(paths).forEach(function(pathStr) {
-        Object.keys(paths[pathStr]).forEach(function(method) {
-            var p = paths[pathStr][method];
-            var uri;
-            if(p.hasOwnProperty('x-monitor') && !p['x-monitor']) {
-                return;
-            }
-            uri = new URI(pathStr, {}, true);
-            if(!p['x-amples']) {
-                ret.push(constructTestCase(
-                    pathStr,
-                    uri.toString({params: defParams}),
-                    method,
-                    {},
-                    {}
-                ));
-                return;
-            }
-            p['x-amples'].forEach(function(ex) {
-                ex.request = ex.request || {};
-                ret.push(constructTestCase(
-                    ex.title,
-                    uri.toString({params: Object.assign({}, defParams, ex.request.params || {})}),
-                    method,
-                    ex.request,
-                    ex.response || {}
-                ));
-            });
-        });
+      if (Object.prototype.hasOwnProperty.call(p, 'x-monitor') && !p['x-monitor']) {
+        return;
+      }
+
+      if (!p['x-amples']) {
+        ret.push(constructTestCase(
+          pathStr,
+          uri.toString({ params: defParams }),
+          method,
+          {},
+          {}
+        ));
+        return;
+      }
+      p['x-amples'].forEach((ex) => {
+        const request = ex.request || {};
+        ret.push(constructTestCase(
+          ex.title,
+          uri.toString({ params: Object.assign({}, defParams, request.params || {}) }),
+          method,
+          request,
+          ex.response || {}
+        ));
+      });
     });
+  });
 
-    return ret;
-
+  return ret;
 }
 
 
 function cmp(result, expected, errMsg) {
-
-    if(expected === null || expected === undefined) {
-        // nothing to expect, so we can return
-        return true;
-    }
-    if(result === null || result === undefined) {
-        result = '';
-    }
-
-    if(expected.constructor === Object) {
-        Object.keys(expected).forEach(function(key) {
-            var val = expected[key];
-            assert.deepEqual(result.hasOwnProperty(key), true, 'Body field ' + key + ' not found in response!');
-            cmp(result[key], val, key + ' body field mismatch!');
-        });
-        return true;
-    } else if(expected.constructor === Array) {
-        if(result.constructor !== Array) {
-            assert.deepEqual(result, expected, errMsg);
-            return true;
-        }
-        // only one item in expected - compare them all
-        if(expected.length === 1 && result.length > 1) {
-            result.forEach(function(item) {
-                cmp(item, expected[0], errMsg);
-            });
-            return true;
-        }
-        // more than one item expected, check them one by one
-        if(expected.length !== result.length) {
-            assert.deepEqual(result, expected, errMsg);
-            return true;
-        }
-        expected.forEach(function(item, idx) {
-            cmp(result[idx], item, errMsg);
-        });
-        return true;
-    }
-
-    if(expected.length > 1 && expected[0] === '/' && expected[expected.length - 1] === '/') {
-        if((new RegExp(expected.slice(1, -1))).test(result)) {
-            return true;
-        }
-    } else if(expected.length === 0 && result.length === 0) {
-        return true;
-    } else if(result === expected || result.startsWith(expected)) {
-        return true;
-    }
-
-    assert.deepEqual(result, expected, errMsg);
+  if (expected === null || expected === undefined) {
+    // nothing to expect, so we can return
     return true;
+  }
+  if (result === null || result === undefined) {
+    result = ''; // eslint-disable-line no-param-reassign
+  }
 
+  if (expected.constructor === Object) {
+    Object.keys(expected).forEach((key) => {
+      const val = expected[key];
+      assert.deepEqual(
+        Object.prototype.hasOwnProperty.call(result, key),
+        true,
+        `Body field ${key} not found in response!`
+      );
+      cmp(result[key], val, `${key} body field mismatch!`);
+    });
+    return true;
+  } else if (expected.constructor === Array) {
+    if (result.constructor !== Array) {
+      assert.deepEqual(result, expected, errMsg);
+      return true;
+    }
+    // only one item in expected - compare them all
+    if (expected.length === 1 && result.length > 1) {
+      result.forEach((item) => {
+        cmp(item, expected[0], errMsg);
+      });
+      return true;
+    }
+    // more than one item expected, check them one by one
+    if (expected.length !== result.length) {
+      assert.deepEqual(result, expected, errMsg);
+      return true;
+    }
+    expected.forEach((item, idx) => {
+      cmp(result[idx], item, errMsg);
+    });
+    return true;
+  }
+
+  if (expected.length > 1 && expected[0] === '/' && expected[expected.length - 1] === '/') {
+    if ((new RegExp(expected.slice(1, -1))).test(result)) {
+      return true;
+    }
+  } else if (expected.length === 0 && result.length === 0) {
+    return true;
+  } else if (result === expected || result.startsWith(expected)) {
+    return true;
+  }
+
+  assert.deepEqual(result, expected, errMsg);
+  return true;
 }
 
 
 function validateTestResponse(testCase, res) {
+  const expRes = testCase.response;
 
-    var expRes = testCase.response;
-
-    // check the status
-    assert.status(res, expRes.status);
-    // check the headers
-    Object.keys(expRes.headers).forEach(function(key) {
-        var val = expRes.headers[key];
-        assert.deepEqual(res.headers.hasOwnProperty(key), true, 'Header ' + key + ' not found in response!');
-        cmp(res.headers[key], val, key + ' header mismatch!');
-    });
-    // check the body
-    if(!expRes.body) {
-        return true;
-    }
-    res.body = res.body || '';
-    if(Buffer.isBuffer(res.body)) { res.body = res.body.toString(); }
-    if(expRes.body.constructor !== res.body.constructor) {
-        if(expRes.body.constructor === String) {
-            res.body = JSON.stringify(res.body);
-        } else {
-            res.body = JSON.parse(res.body);
-        }
-    }
-    // check that the body type is the same
-    if(expRes.body.constructor !== res.body.constructor) {
-        throw new Error('Expected a body of type ' + expRes.body.constructor + ' but gotten ' + res.body.constructor);
-    }
-
-    // compare the bodies
-    cmp(res.body, expRes.body, 'Body mismatch!');
-
+  // check the status
+  assert.status(res, expRes.status);
+  // check the headers
+  Object.keys(expRes.headers).forEach((key) => {
+    const val = expRes.headers[key];
+    assert.deepEqual(
+      Object.prototype.hasOwnProperty.call(res, key),
+      true,
+      `Header ${key} not found in response!`
+    );
+    cmp(res.headers[key], val, `${key} header mismatch!`);
+  });
+  // check the body
+  if (!expRes.body) {
     return true;
+  }
+  res.body = res.body || '';
+  if (Buffer.isBuffer(res.body)) { res.body = res.body.toString(); }
+  if (expRes.body.constructor !== res.body.constructor) {
+    if (expRes.body.constructor === String) {
+      res.body = JSON.stringify(res.body);
+    } else {
+      res.body = JSON.parse(res.body);
+    }
+  }
+  // check that the body type is the same
+  if (expRes.body.constructor !== res.body.constructor) {
+    throw new Error(`Expected a body of type ${expRes.body.constructor} but gotten ${res.body.constructor}`);
+  }
 
+  // compare the bodies
+  cmp(res.body, expRes.body, 'Body mismatch!');
+
+  return true;
 }
 
 
-describe('Swagger spec', function() {
+describe('Swagger spec', function () { // eslint-disable-line func-names
+  // the variable holding the spec
+  let spec = staticSpecLoad();
+  // default params, if given
+  let defParams = spec['x-default-params'] || {};
 
-    // the variable holding the spec
-    var spec = staticSpecLoad();
-    // default params, if given
-    var defParams = spec['x-default-params'] || {};
+  this.timeout(20000);
 
-    this.timeout(20000);
+  before(() => server.start());
 
-    before(function () {
-        return server.start();
+  it('get the spec', () => preq.get(`${server.config.uri}?spec`)
+    .then((res) => {
+      assert.status(200);
+      assert.contentType(res, 'application/json');
+      assert.notDeepEqual(res.body, undefined, 'No body received!');
+      spec = res.body;
+    }));
+
+  it('spec validation', () => {
+    if (spec['x-default-params']) {
+      defParams = spec['x-default-params'];
+    }
+    // check the high-level attributes
+    ['info', 'swagger', 'paths'].forEach((prop) => {
+      assert.deepEqual(!!spec[prop], true, `No ${prop} field present!`);
     });
+    // no paths - no love
+    assert.deepEqual(!!Object.keys(spec.paths), true, 'No paths given in the spec!');
+    // now check each path
+    Object.keys(spec.paths).forEach((pathStr) => {
+      const path = spec.paths[pathStr];
 
-    it('get the spec', function() {
-        return preq.get(server.config.uri + '?spec')
-        .then(function(res) {
-            assert.status(200);
-            assert.contentType(res, 'application/json');
-            assert.notDeepEqual(res.body, undefined, 'No body received!');
-            spec = res.body;
-        });
-    });
-
-    it('spec validation', function() {
-        if(spec['x-default-params']) {
-            defParams = spec['x-default-params'];
+      assert.deepEqual(!!pathStr, true, 'A path cannot have a length of zero!');
+      assert.deepEqual(!!Object.keys(path), true, `No methods defined for path: ${pathStr}`);
+      Object.keys(path).forEach((method) => {
+        const mSpec = path[method];
+        if (Object.prototype.hasOwnProperty.call(mSpec, 'x-monitor') && !mSpec['x-monitor']) {
+          return;
         }
-        // check the high-level attributes
-        ['info', 'swagger', 'paths'].forEach(function(prop) {
-            assert.deepEqual(!!spec[prop], true, 'No ' + prop + ' field present!');
-        });
-        // no paths - no love
-        assert.deepEqual(!!Object.keys(spec.paths), true, 'No paths given in the spec!');
-        // now check each path
-        Object.keys(spec.paths).forEach(function(pathStr) {
-            var path;
-            assert.deepEqual(!!pathStr, true, 'A path cannot have a length of zero!');
-            path = spec.paths[pathStr];
-            assert.deepEqual(!!Object.keys(path), true, 'No methods defined for path: ' + pathStr);
-            Object.keys(path).forEach(function(method) {
-                var mSpec = path[method];
-                if(mSpec.hasOwnProperty('x-monitor') && !mSpec['x-monitor']) {
-                    return;
-                }
-                validateExamples(pathStr, defParams, mSpec['x-amples']);
-            });
-        });
+        validateExamples(pathStr, defParams, mSpec['x-amples']);
+      });
     });
+  });
 
-    describe('routes', function() {
-
-        constructTests(spec.paths, defParams).forEach(function(testCase) {
-            it(testCase.title, function() {
-                return preq(testCase.request)
-                .then(function(res) {
-                    validateTestResponse(testCase, res);
-                }, function(err) {
-                    validateTestResponse(testCase, err);
-                });
-            });
-        });
-
+  describe('routes', () => {
+    constructTests(spec.paths, defParams).forEach((testCase) => {
+      it(testCase.title, () => preq(testCase.request)
+        .then((res) => {
+          validateTestResponse(testCase, res);
+        }, (err) => {
+          validateTestResponse(testCase, err);
+        }));
     });
-
+  });
 });
-

--- a/test/features/ex/errors.js
+++ b/test/features/ex/errors.js
@@ -1,89 +1,78 @@
+/* global describe it before */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
+const preq = require('preq');
+const assert = require('../../utils/assert.js');
+const server = require('../../utils/server.js');
 
-var preq   = require('preq');
-var assert = require('../../utils/assert.js');
-var server = require('../../utils/server.js');
 
+describe('errors', function testErrors() {
+  this.timeout(20000);
 
-describe('errors', function() {
+  before(() => server.start());
 
-    this.timeout(20000);
+  // common URI prefix for the errors
+  const uri = `${server.config.uri}ex/err/`;
 
-    before(function () { return server.start(); });
+  it('array creation error', () => preq.get({
+    uri: `${uri}array`,
+  }).then((res) => {
+    // if we are here, no error was thrown, not good
+    throw new Error(`Expected an error to be thrown, got status: ${res.status}`);
+  }, (err) => {
+    // inspect the status
+    assert.deepEqual(err.status, 500);
+    // check the error title
+    assert.deepEqual(err.body.title, 'RangeError');
+  }));
 
-    // common URI prefix for the errors
-    var uri = server.config.uri + 'ex/err/';
+  it('file read error', () => preq.get({
+    uri: `${uri}file`,
+  }).then((res) => {
+    // if we are here, no error was thrown, not good
+    throw new Error(`Expected an error to be thrown, got status: ${res.status}`);
+  }, (err) => {
+    // inspect the status
+    assert.deepEqual(err.status, 500);
+    // check the error title
+    assert.deepEqual(err.body.title, 'Error');
+  }));
 
-    it('array creation error', function() {
-        return preq.get({
-            uri: uri + 'array'
-        }).then(function(res) {
-            // if we are here, no error was thrown, not good
-            throw new Error('Expected an error to be thrown, got status: ' + res.status);
-        }, function(err) {
-            // inspect the status
-            assert.deepEqual(err.status, 500);
-            // check the error title
-            assert.deepEqual(err.body.title, 'RangeError');
-        });
-    });
+  it('constraint check error', () => preq.get({
+    uri: `${uri}manual/error`,
+  }).then((res) => {
+    // if we are here, no error was thrown, not good
+    throw new Error(`Expected an error to be thrown, got status: ${res.status}`);
+  }, (err) => {
+    // inspect the status
+    assert.deepEqual(err.status, 500);
+    // check the error title
+    assert.deepEqual(err.body.title, 'Error');
+  }));
 
-    it('file read error', function() {
-        return preq.get({
-            uri: uri + 'file'
-        }).then(function(res) {
-            // if we are here, no error was thrown, not good
-            throw new Error('Expected an error to be thrown, got status: ' + res.status);
-        }, function(err) {
-            // inspect the status
-            assert.deepEqual(err.status, 500);
-            // check the error title
-            assert.deepEqual(err.body.title, 'Error');
-        });
-    });
+  it('access denied error', () => preq.get({
+    uri: `${uri}manual/deny`,
+  }).then((res) => {
+    // if we are here, no error was thrown, not good
+    throw new Error(`Expected an error to be thrown, got status: ${res.status}`);
+  }, (err) => {
+    // inspect the status
+    assert.deepEqual(err.status, 403);
+    // check the error title
+    assert.deepEqual(err.body.type, 'access_denied');
+  }));
 
-    it('constraint check error', function() {
-        return preq.get({
-            uri: uri + 'manual/error'
-        }).then(function(res) {
-            // if we are here, no error was thrown, not good
-            throw new Error('Expected an error to be thrown, got status: ' + res.status);
-        }, function(err) {
-            // inspect the status
-            assert.deepEqual(err.status, 500);
-            // check the error title
-            assert.deepEqual(err.body.title, 'Error');
-        });
-    });
-
-    it('access denied error', function() {
-        return preq.get({
-            uri: uri + 'manual/deny'
-        }).then(function(res) {
-            // if we are here, no error was thrown, not good
-            throw new Error('Expected an error to be thrown, got status: ' + res.status);
-        }, function(err) {
-            // inspect the status
-            assert.deepEqual(err.status, 403);
-            // check the error title
-            assert.deepEqual(err.body.type, 'access_denied');
-        });
-    });
-
-    it('authorisation error', function() {
-        return preq.get({
-            uri: uri + 'manual/auth'
-        }).then(function(res) {
-            // if we are here, no error was thrown, not good
-            throw new Error('Expected an error to be thrown, got status: ' + res.status);
-        }, function(err) {
-            // inspect the status
-            assert.deepEqual(err.status, 401);
-            // check the error title
-            assert.deepEqual(err.body.type, 'unauthorized');
-        });
-    });
-
+  it('authorisation error', () => preq.get({
+    uri: `${uri}manual/auth`,
+  }).then((res) => {
+    // if we are here, no error was thrown, not good
+    throw new Error(`Expected an error to be thrown, got status: ${res.status}`);
+  }, (err) => {
+    // inspect the status
+    assert.deepEqual(err.status, 401);
+    // check the error title
+    assert.deepEqual(err.body.type, 'unauthorized');
+  }));
 });
-

--- a/test/features/info/info.js
+++ b/test/features/info/info.js
@@ -1,70 +1,61 @@
+/* global describe it before */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
+const preq = require('preq');
+const assert = require('../../utils/assert.js');
+const server = require('../../utils/server.js');
 
-var preq   = require('preq');
-var assert = require('../../utils/assert.js');
-var server = require('../../utils/server.js');
 
+describe('service information', function testServiceInfo() {
+  this.timeout(20000);
 
-describe('service information', function() {
+  before(() => server.start());
 
-    this.timeout(20000);
+  // common URI prefix for info tests
+  const infoUri = `${server.config.uri}_info/`;
 
-    before(function () { return server.start(); });
-
-    // common URI prefix for info tests
-    var infoUri = server.config.uri + '_info/';
-
-    // common function used for generating requests
-    // and checking their return values
-    function checkRet(fieldName) {
-        return preq.get({
-            uri: infoUri + fieldName
-        }).then(function(res) {
-            // check the returned Content-Type header
-            assert.contentType(res, 'application/json');
-            // the status as well
-            assert.status(res, 200);
-            // finally, check the body has the specified field
-            assert.notDeepEqual(res.body, undefined, 'No body returned!');
-            assert.notDeepEqual(res.body[fieldName], undefined, 'No ' + fieldName + ' field returned!');
-        });
-    }
-
-    it('should get the service name', function() {
-        return checkRet('name');
+  // common function used for generating requests
+  // and checking their return values
+  function checkRet(fieldName) {
+    return preq.get({
+      uri: infoUri + fieldName,
+    }).then((res) => {
+      // check the returned Content-Type header
+      assert.contentType(res, 'application/json');
+      // the status as well
+      assert.status(res, 200);
+      // finally, check the body has the specified field
+      assert.notDeepEqual(res.body, undefined, 'No body returned!');
+      assert.notDeepEqual(res.body[fieldName], undefined, `No ${fieldName} field returned!`);
     });
+  }
 
-    it('should get the service version', function() {
-        return checkRet('version');
-    });
+  it('should get the service name', () => checkRet('name'));
 
-    it('should redirect to the service home page', function() {
-        return preq.get({
-            uri: infoUri + 'home',
-            followRedirect: false
-        }).then(function(res) {
-            // check the status
-            assert.status(res, 301);
-        });
-    });
+  it('should get the service version', () => checkRet('version'));
 
-    it('should get the service info', function() {
-        return preq.get({
-            uri: infoUri
-        }).then(function(res) {
-            // check the status
-            assert.status(res, 200);
-            // check the returned Content-Type header
-            assert.contentType(res, 'application/json');
-            // inspect the body
-            assert.notDeepEqual(res.body, undefined, 'No body returned!');
-            assert.notDeepEqual(res.body.name, undefined, 'No name field returned!');
-            assert.notDeepEqual(res.body.version, undefined, 'No version field returned!');
-            assert.notDeepEqual(res.body.description, undefined, 'No description field returned!');
-            assert.notDeepEqual(res.body.home, undefined, 'No home field returned!');
-        });
-    });
+  it('should redirect to the service home page', () => preq.get({
+    uri: `${infoUri}home`,
+    followRedirect: false,
+  }).then((res) => {
+    // check the status
+    assert.status(res, 301);
+  }));
 
+  it('should get the service info', () => preq.get({
+    uri: infoUri,
+  }).then((res) => {
+    // check the status
+    assert.status(res, 200);
+    // check the returned Content-Type header
+    assert.contentType(res, 'application/json');
+    // inspect the body
+    assert.notDeepEqual(res.body, undefined, 'No body returned!');
+    assert.notDeepEqual(res.body.name, undefined, 'No name field returned!');
+    assert.notDeepEqual(res.body.version, undefined, 'No version field returned!');
+    assert.notDeepEqual(res.body.description, undefined, 'No description field returned!');
+    assert.notDeepEqual(res.body.home, undefined, 'No home field returned!');
+  }));
 });
-

--- a/test/features/v1/page.js
+++ b/test/features/v1/page.js
@@ -1,69 +1,62 @@
+/* global describe it before */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
+const preq = require('preq');
+const assert = require('../../utils/assert.js');
+const server = require('../../utils/server.js');
 
-var preq   = require('preq');
-var assert = require('../../utils/assert.js');
-var server = require('../../utils/server.js');
 
+describe('page gets', function testPageGets() {
+  this.timeout(20000);
 
-describe('page gets', function() {
+  before(() => server.start());
 
-    this.timeout(20000);
+  // common URI prefix for the page
+  const uri = `${server.config.uri}en.wikipedia.org/v1/page/Mulholland%20Drive%20%28film%29/`;
 
-    before(function () { return server.start(); });
+  it('should get the whole page body', () => preq.get({
+    uri,
+  }).then((res) => {
+    // check the status
+    assert.status(res, 200);
+    // check the returned Content-Type header
+    assert.contentType(res, 'text/html');
+    // inspect the body
+    assert.notDeepEqual(res.body, undefined, 'No body returned!');
+    // this should be the right page
+    if (!/<\s*?h1.+Mulholland/.test(res.body)) {
+      throw new Error('Not the title I was expecting!');
+    }
+  }));
 
-    // common URI prefix for the page
-    var uri = server.config.uri + 'en.wikipedia.org/v1/page/Mulholland%20Drive%20%28film%29/';
+  it('should get only the leading section', () => preq.get({
+    uri: `${uri}lead`,
+  }).then((res) => {
+    // check the status
+    assert.status(res, 200);
+    // check the returned Content-Type header
+    assert.contentType(res, 'text/html');
+    // inspect the body
+    assert.notDeepEqual(res.body, undefined, 'No body returned!');
+    // this should be the right page
+    if (!/Mulholland/.test(res.body)) {
+      throw new Error('Not the page I was expecting!');
+    }
+    // .. and should start with <div id="lead_section">
+    if (!/^<div id="lead_section">/.test(res.body)) {
+      throw new Error('This is not a leading section!');
+    }
+  }));
 
-    it('should get the whole page body', function() {
-        return preq.get({
-            uri: uri
-        }).then(function(res) {
-            // check the status
-            assert.status(res, 200);
-            // check the returned Content-Type header
-            assert.contentType(res, 'text/html');
-            // inspect the body
-            assert.notDeepEqual(res.body, undefined, 'No body returned!');
-            // this should be the right page
-            if(!/<\s*?h1.+Mulholland/.test(res.body)) {
-                throw new Error('Not the title I was expecting!');
-            }
-        });
-    });
-
-    it('should get only the leading section', function() {
-        return preq.get({
-            uri: uri + 'lead'
-        }).then(function(res) {
-            // check the status
-            assert.status(res, 200);
-            // check the returned Content-Type header
-            assert.contentType(res, 'text/html');
-            // inspect the body
-            assert.notDeepEqual(res.body, undefined, 'No body returned!');
-            // this should be the right page
-            if(!/Mulholland/.test(res.body)) {
-                throw new Error('Not the page I was expecting!');
-            }
-            // .. and should start with <div id="lead_section">
-            if(!/^<div id="lead_section">/.test(res.body)) {
-                throw new Error('This is not a leading section!');
-            }
-        });
-    });
-
-    it('should throw a 404 for a non-existent page', function() {
-        return preq.get({
-            uri: server.config.uri + 'en.wikipedia.org/v1/page/Foobar_and_friends'
-        }).then(function(res) {
-            // if we are here, no error was thrown, not good
-            throw new Error('Expected an error to be thrown, got status: ', res.status);
-        }, function(err) {
-            // inspect the status
-            assert.deepEqual(err.status, 404);
-        });
-    });
-
+  it('should throw a 404 for a non-existent page', () => preq.get({
+    uri: `${server.config.uri}en.wikipedia.org/v1/page/Foobar_and_friends`,
+  }).then((res) => {
+    // if we are here, no error was thrown, not good
+    throw new Error('Expected an error to be thrown, got status: ', res.status);
+  }, (err) => {
+    // inspect the status
+    assert.deepEqual(err.status, 404);
+  }));
 });
-

--- a/test/features/v1/siteinfo.js
+++ b/test/features/v1/siteinfo.js
@@ -1,71 +1,62 @@
+/* global describe it before */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
+const preq = require('preq');
+const assert = require('../../utils/assert.js');
+const server = require('../../utils/server.js');
 
-var preq   = require('preq');
-var assert = require('../../utils/assert.js');
-var server = require('../../utils/server.js');
 
+describe('wiki site info', function testWikiSiteInfo() {
+  this.timeout(20000);
 
-describe('wiki site info', function() {
+  before(() => server.start());
 
-    this.timeout(20000);
+  // common URI prefix for v1
+  const uri = `${server.config.uri}en.wikipedia.org/v1/siteinfo/`;
 
-    before(function () { return server.start(); });
+  it('should get all general enwiki site info', () => preq.get({
+    uri,
+  }).then((res) => {
+    // check the status
+    assert.status(res, 200);
+    // check the returned Content-Type header
+    assert.contentType(res, 'application/json');
+    // inspect the body
+    assert.notDeepEqual(res.body, undefined, 'No body returned!');
+    assert.notDeepEqual(res.body.server, undefined, 'No server field returned!');
+  }));
 
-    // common URI prefix for v1
-    var uri = server.config.uri + 'en.wikipedia.org/v1/siteinfo/';
+  it('should get the mainpage setting of enwiki', () => preq.get({
+    uri: `${uri}mainpage`,
+  }).then((res) => {
+    // check the status
+    assert.status(res, 200);
+    // check the returned Content-Type header
+    assert.contentType(res, 'application/json');
+    // inspect the body
+    assert.notDeepEqual(res.body, undefined, 'No body returned!');
+    assert.deepEqual(res.body.mainpage, 'Main Page', 'enwiki mainpage mismatch!');
+  }));
 
-    it('should get all general enwiki site info', function() {
-        return preq.get({
-            uri: uri
-        }).then(function(res) {
-            // check the status
-            assert.status(res, 200);
-            // check the returned Content-Type header
-            assert.contentType(res, 'application/json');
-            // inspect the body
-            assert.notDeepEqual(res.body, undefined, 'No body returned!');
-            assert.notDeepEqual(res.body.server, undefined, 'No server field returned!');
-        });
-    });
+  it('should fail to get a non-existent setting of enwiki', () => preq.get({
+    uri: `${uri}dummy_wiki_setting`,
+  }).then((res) => {
+    // if we are here, no error was thrown, not good
+    throw new Error(`Expected an error to be thrown, got status: ${res.status}`);
+  }, (err) => {
+    // inspect the status
+    assert.deepEqual(err.status, 404);
+  }));
 
-    it('should get the mainpage setting of enwiki', function() {
-        return preq.get({
-            uri: uri + 'mainpage'
-        }).then(function(res) {
-            // check the status
-            assert.status(res, 200);
-            // check the returned Content-Type header
-            assert.contentType(res, 'application/json');
-            // inspect the body
-            assert.notDeepEqual(res.body, undefined, 'No body returned!');
-            assert.deepEqual(res.body.mainpage, 'Main Page', 'enwiki mainpage mismatch!');
-        });
-    });
-
-    it('should fail to get a non-existent setting of enwiki', function() {
-        return preq.get({
-            uri: uri + 'dummy_wiki_setting'
-        }).then(function(res) {
-            // if we are here, no error was thrown, not good
-            throw new Error('Expected an error to be thrown, got status: ' + res.status);
-        }, function(err) {
-            // inspect the status
-            assert.deepEqual(err.status, 404);
-        });
-    });
-
-    it('should fail to get info from a non-existent wiki', function() {
-        return preq.get({
-            uri: server.config.uri + 'non.existent.wiki/v1/siteinfo/'
-        }).then(function(res) {
-            // if we are here, no error was thrown, not good
-            throw new Error('Expected an error to be thrown, got status: ' + res.status);
-        }, function(err) {
-            // inspect the status
-            assert.deepEqual(err.status, 504);
-        });
-    });
-
+  it('should fail to get info from a non-existent wiki', () => preq.get({
+    uri: `${server.config.uri}non.existent.wiki/v1/siteinfo/`,
+  }).then((res) => {
+    // if we are here, no error was thrown, not good
+    throw new Error(`Expected an error to be thrown, got status: ${res.status}`);
+  }, (err) => {
+    // inspect the status
+    assert.deepEqual(err.status, 504);
+  }));
 });
-

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,1 @@
-'use strict';
-
-
-// Run jshint as part of normal testing
-require('mocha-jshint')();
-
+'use strict'; // eslint-disable-line strict

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -1,17 +1,33 @@
+/* eslint no-console: 0 */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
+const assert = require('assert');
 
-var assert = require('assert');
+function deepEqual(result, expected, message) {
+  try {
+    if (typeof expected === 'string') {
+      assert.ok(result === expected || (new RegExp(expected).test(result)));
+    } else {
+      assert.deepEqual(result, expected, message);
+    }
+  } catch (e) {
+    console.log(`Expected:\n${JSON.stringify(expected, null, 2)}`);
+    console.log(`Result:\n${JSON.stringify(result, null, 2)}`);
+    throw e;
+  }
+}
 
 
 /**
  * Asserts whether the return status was as expected
  */
 function status(res, expected) {
-
-    deepEqual(res.status, expected,
-        'Expected status to be ' + expected + ', but was ' + res.status);
-
+  deepEqual(
+    res.status, expected,
+    `Expected status to be ${expected}, but was ${res.status}`
+  );
 }
 
 
@@ -19,85 +35,61 @@ function status(res, expected) {
  * Asserts whether content type was as expected
  */
 function contentType(res, expected) {
-
-    var actual = res.headers['content-type'];
-    deepEqual(actual, expected,
-        'Expected content-type to be ' + expected + ', but was ' + actual);
-
+  const actual = res.headers['content-type'];
+  deepEqual(
+    actual, expected,
+    `Expected content-type to be ${expected}, but was ${actual}`
+  );
 }
 
 
 function isDeepEqual(result, expected, message) {
-
-    try {
-        if (typeof expected === 'string') {
-            assert.ok(result === expected || (new RegExp(expected).test(result)), message);
-        } else {
-            assert.deepEqual(result, expected, message);
-        }
-        return true;
-    } catch (e) {
-        return false;
+  try {
+    if (typeof expected === 'string') {
+      assert.ok(result === expected || (new RegExp(expected).test(result)), message);
+    } else {
+      assert.deepEqual(result, expected, message);
     }
-
-}
-
-
-function deepEqual(result, expected, message) {
-
-    try {
-        if (typeof expected === 'string') {
-            assert.ok(result === expected || (new RegExp(expected).test(result)));
-        } else {
-            assert.deepEqual(result, expected, message);
-        }
-    } catch (e) {
-        console.log('Expected:\n' + JSON.stringify(expected, null, 2));
-        console.log('Result:\n' + JSON.stringify(result, null, 2));
-        throw e;
-    }
-
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 
 function notDeepEqual(result, expected, message) {
-
-    try {
-        assert.notDeepEqual(result, expected, message);
-    } catch (e) {
-        console.log('Not expected:\n' + JSON.stringify(expected, null, 2));
-        console.log('Result:\n' + JSON.stringify(result, null, 2));
-        throw e;
-    }
-
+  try {
+    assert.notDeepEqual(result, expected, message);
+  } catch (e) {
+    console.log(`Not expected:\n${JSON.stringify(expected, null, 2)}`);
+    console.log(`Result:\n${JSON.stringify(result, null, 2)}`);
+    throw e;
+  }
 }
 
 
 function fails(promise, onRejected) {
+  let failed = false;
 
-    var failed = false;
+  function trackFailure(e) {
+    failed = true;
+    return onRejected(e);
+  }
 
-    function trackFailure(e) {
-        failed = true;
-        return onRejected(e);
+  function check() {
+    if (!failed) {
+      throw new Error('expected error was not thrown');
     }
+  }
 
-    function check() {
-        if (!failed) {
-            throw new Error('expected error was not thrown');
-        }
-    }
-
-    return promise.catch(trackFailure).then(check);
-
+  return promise.catch(trackFailure).then(check);
 }
 
 
-module.exports.ok             = assert.ok;
-module.exports.fails          = fails;
-module.exports.deepEqual      = deepEqual;
-module.exports.isDeepEqual    = isDeepEqual;
-module.exports.notDeepEqual   = notDeepEqual;
-module.exports.contentType    = contentType;
-module.exports.status         = status;
-
+module.exports.ok = assert.ok;
+module.exports.fails = fails;
+module.exports.deepEqual = deepEqual;
+module.exports.isDeepEqual = isDeepEqual;
+module.exports.notDeepEqual = notDeepEqual;
+module.exports.contentType = contentType;
+module.exports.status = status;

--- a/test/utils/logStream.js
+++ b/test/utils/logStream.js
@@ -1,34 +1,36 @@
+/* eslint no-console: 0 */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
-var bunyan = require('bunyan');
+const bunyan = require('bunyan');
 
 function logStream(logStdout) {
-
-  var log = [];
-  var parrot = bunyan.createLogger({
+  const log = [];
+  const parrot = bunyan.createLogger({
     name: 'test-logger',
-    level: 'warn'
+    level: 'warn',
   });
 
-  function write(chunk, encoding, callback) {
+  function write(chunk /* encoding, callback */) {
     try {
-        var entry = JSON.parse(chunk);
-        var levelMatch = /^(\w+)/.exec(entry.levelPath);
-        if (logStdout && levelMatch) {
-            var level = levelMatch[1];
-            if (parrot[level]) {
-                parrot[level](entry);
-            }
+      const entry = JSON.parse(chunk);
+      const levelMatch = /^(\w+)/.exec(entry.levelPath);
+      if (logStdout && levelMatch) {
+        const level = levelMatch[1];
+        if (parrot[level]) {
+          parrot[level](entry);
         }
+      }
     } catch (e) {
-        console.error('something went wrong trying to parrot a log entry', e, chunk);
+      console.error('something went wrong trying to parrot a log entry', e, chunk);
     }
 
     log.push(chunk);
   }
 
   // to implement the stream writer interface
-  function end(chunk, encoding, callback) {
+  function end(/* chunk, encoding, callback */) {
   }
 
   function get() {
@@ -36,32 +38,30 @@ function logStream(logStdout) {
   }
 
   function slice() {
-
-    var begin = log.length;
-    var end   = null;
+    const begin = log.length;
+    let end2 = null;
 
     function halt() {
-      if (end === null) {
-        end = log.length;
+      if (end2 === null) {
+        end2 = log.length;
       }
     }
 
-    function get() {
-      return log.slice(begin, end);
+    function get2() {
+      return log.slice(begin, end2);
     }
 
     return {
-      halt: halt,
-      get: get
+      halt,
+      get2,
     };
-
   }
 
   return {
-    write: write,
-    end: end,
-    slice: slice,
-    get: get
+    write,
+    end,
+    slice,
+    get,
   };
 }
 

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -1,71 +1,66 @@
+/* eslint no-console: 0 */
+
+// eslint-disable-next-line strict,lines-around-directive
 'use strict';
 
-
-// mocha defines to avoid JSHint breakage
-/* global describe, it, before, beforeEach, after, afterEach */
-
-
-var BBPromise = require('bluebird');
-var ServiceRunner = require('service-runner');
-var logStream = require('./logStream');
-var fs = require('fs');
-var assert = require('./assert');
-var yaml = require('js-yaml');
-var extend = require('extend');
+const BBPromise = require('bluebird');
+const ServiceRunner = require('service-runner');
+const logStream = require('./logStream');
+const fs = require('fs');
+const assert = require('./assert');
+const yaml = require('js-yaml');
+const extend = require('extend');
 
 
 // set up the configuration
-var config = {
-    conf: yaml.safeLoad(fs.readFileSync(__dirname + '/../../config.yaml'))
+let config = {
+  conf: yaml.safeLoad(fs.readFileSync(`${__dirname}/../../config.dev.yaml`)),
 };
 // build the API endpoint URI by supposing the actual service
 // is the last one in the 'services' list in the config file
-var myServiceIdx = config.conf.services.length - 1;
-var myService = config.conf.services[myServiceIdx];
-config.uri = 'http://localhost:' + myService.conf.port + '/';
+const myServiceIdx = config.conf.services.length - 1;
+const myService = config.conf.services[myServiceIdx];
+config.uri = `http://localhost:${myService.conf.port}/`;
 config.service = myService;
 // no forking, run just one process when testing
 config.conf.num_workers = 0;
 // have a separate, in-memory logger only
 config.conf.logging = {
-    name: 'test-log',
-    level: 'trace',
-    stream: logStream()
+  name: 'test-log',
+  level: 'trace',
+  stream: logStream(),
 };
 // make a deep copy of it for later reference
-var origConfig = extend(true, {}, config);
+const origConfig = extend(true, {}, config);
 
-var stop = function () {};
-var options = null;
-var runner = new ServiceRunner();
+let stop = function stop() {};
+let options = null;
+const runner = new ServiceRunner();
 
 
 function start(_options) {
+  const normalizedOptions = _options || {};
 
-    _options = _options || {};
-
-    if (!assert.isDeepEqual(options, _options)) {
-        console.log('server options changed; restarting');
-        stop();
-        options = _options;
-        // set up the config
-        config = extend(true, {}, origConfig);
-        extend(true, config.conf.services[myServiceIdx].conf, options);
-        return runner.run(config.conf)
-        .then(function(servers) {
-            var server = servers[0];
-            stop = function () {
-                console.log('stopping test server');
-                server.close();
-                stop = function () {};
-            };
-            return true;
-        });
-    } else {
-        return BBPromise.resolve();
-    }
-
+  if (!assert.isDeepEqual(options, normalizedOptions)) {
+    console.log('server options changed; restarting');
+    stop();
+    options = normalizedOptions;
+    // set up the config
+    config = extend(true, {}, origConfig);
+    extend(true, config.conf.services[myServiceIdx].conf, options);
+    return runner.run(config.conf)
+      .then((servers) => {
+        const server = servers[0];
+        stop = function stop() { // eslint-disable-line no-shadow
+          console.log('stopping test server');
+          server.close();
+          stop = function stop() {}; // eslint-disable-line no-shadow,no-func-assign
+        };
+        return true;
+      });
+  }
+  return BBPromise.resolve();
 }
 
 module.exports.config = config;
-module.exports.start  = start;
+module.exports.start = start;


### PR DESCRIPTION
Add linting according to the eslint kartotherian rules.

Only test node version 6. Version 4 is fairly old, and does not support the linting rules (mainly the trailing comma pieces) and Mapnik [only supports up to node 6.9.4 for now](https://github.com/mapnik/node-mapnik/issues/724).

Tests are still failing, but that also happened before, so this PR is ready to be reviewed.