### PR TITLE
Test: get rid of custom logger and output errors and warnings to stdout

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -9,7 +9,7 @@ worker_heap_limit_mb: 250
 
 # Logger info
 logging:
-  level: trace
+  level: warn
 #  streams:
 #  # Use gelf-stream -> logstash
 #  - type: gelf

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -5,7 +5,6 @@
 
 const BBPromise = require('bluebird');
 const ServiceRunner = require('service-runner');
-const logStream = require('./logStream');
 const fs = require('fs');
 const assert = require('./assert');
 const yaml = require('js-yaml');
@@ -23,12 +22,6 @@ config.uri = `http://localhost:${myService.conf.port}/`;
 config.service = myService;
 // no forking, run just one process when testing
 config.conf.num_workers = 0;
-// have a separate, in-memory logger only
-config.conf.logging = {
-  name: 'test-log',
-  level: 'trace',
-  stream: logStream(),
-};
 // make a deep copy of it for later reference
 const origConfig = extend(true, {}, config);
 


### PR DESCRIPTION
With the custom logger, when tests fail because the service errors out it show no details.