### PR TITLE
Use forked version of tilelive-vector

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -69,7 +69,6 @@ services:
       modules:
       - "tilelive-bridge"
       - "tilelive-http"
-      - "tilelive-vector"
       - "@kartotherian/autogen"
       - "@kartotherian/babel"
       - "@kartotherian/cassandra"
@@ -77,6 +76,7 @@ services:
       - "@kartotherian/overzoom"
       - "@kartotherian/postgres"
       - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-vector"
       - "tilejson"
 
       requestHandlers:

--- a/config.external.yaml
+++ b/config.external.yaml
@@ -60,7 +60,6 @@ services:
       modules:
       - "tilelive-bridge"
       - "tilelive-http"
-      - "tilelive-vector"
       - "@kartotherian/autogen"
       - "@kartotherian/babel"
       - "@kartotherian/cassandra"
@@ -68,6 +67,7 @@ services:
       - "@kartotherian/overzoom"
       - "@kartotherian/postgres"
       - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-vector"
       - "tilejson"
 
       requestHandlers:

--- a/config.meddo.yaml
+++ b/config.meddo.yaml
@@ -105,7 +105,6 @@ services:
       modules:
       - "tilelive-bridge"
       - "tilelive-http"
-      - "tilelive-vector"
       - "@kartotherian/autogen"
       - "@kartotherian/babel"
       - "@kartotherian/cassandra"
@@ -113,6 +112,7 @@ services:
       - "@kartotherian/overzoom"
       - "@kartotherian/postgres"
       - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-vector"
       - "tilejson"
 
       requestHandlers:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -68,7 +68,6 @@ services:
 
       modules:
       - "tilelive-bridge"
-      - "tilelive-vector"
       - "tilelive-http"
       - "@kartotherian/autogen"
       - "@kartotherian/babel"
@@ -77,6 +76,7 @@ services:
       - "@kartotherian/overzoom"
       - "@kartotherian/postgres"
       - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-vector"
       - "tilejson"
 
       requestHandlers:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tilelive": "~5.12.2",
     "tilelive-bridge": "~2.3.1",
     "tilelive-http": "~0.13.0",
-    "tilelive-vector": "~3.9.4",
+    "@kartotherian/tilelive-vector": "~3.9.6",
     "tilejson": "^1.0.3",
     "@kartotherian/core": "^0.1.1",
     "@kartotherian/server": "^0.0.24",


### PR DESCRIPTION
* includes security fix https://github.com/kartotherian/tilelive-vector/pull/1
* propagates opts to upstream sources https://phabricator.wikimedia.org/T187596