### PR TITLE
Adjust sample config for easier i18n testing

### DIFF
--- a/sources.dev.yaml
+++ b/sources.dev.yaml
@@ -147,25 +147,25 @@ substv4ozview:
   xmlSetParams:
     source: {ref: substv4oz}
 
-osm-localized:
-  uri: babel://
-  params:
-    source: {ref: v4}
-    tag: name
-    combineName: false
-    defaultLanguage: en
-
 # Default OSM PBF source
 osm-pbf:
   public: true
   formats: [pbf]
   uri: overzoom://
   params:
-    source: {ref: osm-localized}
+    source: {ref: v4}
     maxzoom: 19
   overrideInfo:
     attribution: 'Map data © <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
     tiles: ["http://localhost:6533/osm-pbf/{z}/{x}/{y}.pbf"]
+
+babel:
+  uri: babel://
+  params:
+    source: {ref: osm-pbf}
+    tag: name
+    combineName: false
+    defaultLanguage: local
 
 # OSM map with international labeling - will be used as default
 osm-intl:
@@ -180,7 +180,7 @@ osm-intl:
   xml:
     loader: "@kartotherian/osm-bright-style"
   xmlSetParams:
-    source: {ref: osm-pbf}
+    source: {ref: babel}
   overrideInfo:
     attribution: 'Map data © <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
     tiles: ["http://localhost:6533/osm-intl/{z}/{x}/{y}.png"]

--- a/sources.external.yaml
+++ b/sources.external.yaml
@@ -1,6 +1,6 @@
 # Download tiles on the fly from wiki maps service
 gen:
-  uri: https://maps.wikimedia.org/osm-pbf-i18n/{z}/{x}/{y}.pbf
+  uri: https://maps.wikimedia.org/osm-pbf/{z}/{x}/{y}.pbf
 
 babel:
   uri: babel://

--- a/sources.external.yaml
+++ b/sources.external.yaml
@@ -1,6 +1,14 @@
 # Download tiles on the fly from wiki maps service
 gen:
-  uri: https://maps.wikimedia.org/osm-pbf/{z}/{x}/{y}.pbf
+  uri: https://maps.wikimedia.org/osm-pbf-i18n/{z}/{x}/{y}.pbf
+
+babel:
+  uri: babel://
+  params:
+    source: {ref: gen}
+    tag: name
+    combineName: false
+    defaultLanguage: local
 
 # View tiles as generated directly from the database. Don't view zoom0-5
 osm-intl:
@@ -14,7 +22,7 @@ osm-intl:
   xml:
     loader: "@kartotherian/osm-bright-style"
   xmlSetParams:
-    source: {ref: gen}
+    source: {ref: babel}
   defaultHeaders:
     Cache-Control: 'no-cache, no-store, must-revalidate'
     Pragma: no-cache


### PR DESCRIPTION
sources.dev.yaml is re-ordered to be closer to prod

sources.external.dev is pulling tiles with all name_{code}
tags from production and applying babel tag selection locally.