### PR TITLE
Bring @mapbox/tilelive-bridge

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -69,8 +69,8 @@ services:
       sources: sources.test.yaml
 
       modules:
-      - "tilelive-bridge"
       - "tilelive-http"
+      - "tilelive-tmstyle"
       - "@kartotherian/autogen"
       - "@kartotherian/babel"
       - "@kartotherian/cassandra"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "preq": "^0.5.2",
     "service-runner": "^2.2.5",
     "tilelive": "~5.12.2",
-    "tilelive-bridge": "~2.3.1",
+    "@mapbox/tilelive-bridge": "~2.3.1",
     "tilejson": "^1.0.3",
     "tilelive-http": "~0.13.0",
     "tilelive-tmsource": "0.7.0",

--- a/sources.test.yaml
+++ b/sources.test.yaml
@@ -1,6 +1,19 @@
 # Download tiles on the fly from wiki maps service
 gen:
   uri: https://maps.wikimedia.org/osm-pbf/{z}/{x}/{y}.pbf
+  setInfo:
+    vector_layers:
+      - id: landuse
+      - id: waterway
+      - id: water
+      - id: aeroway
+      - id: building
+      - id: road
+      - id: admin
+      - id: country_label
+      - id: place_label
+      - id: poi_label
+      - id: road_label
 
 # View tiles as generated directly from the database. Don't view zoom0-5
 osm-intl:
@@ -10,8 +23,8 @@ osm-intl:
   static: true
   maxheight: 2048
   maxwidth: 2048
-  uri: vector://
-  xml:
-    loader: "@kartotherian/osm-bright-style"
-  xmlSetParams:
+  uri: tmstyle://
+  yaml:
+    npm: ["@kartotherian/osm-bright-style", "project.yml"]
+  yamlSetParams:
     source: {ref: gen}


### PR DESCRIPTION
... so tilelive-bridge doesn't bring his own that comes
with a conflicting version of node-mapnik