### PR TITLE
Combine docker build and run steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,4 @@ sudo: required
 services:
   - docker
 
-before_install:
-  - docker build -t kartotherian .
-
-script: docker run kartotherian
+script: docker build -t kartotherian .

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ENV HOME=/root/ LINK=g++
 ENV IN_DOCKER=1
 COPY . /home/code
 WORKDIR /home/code
-CMD . $NVM_DIR/nvm.sh && nvm use 6.11.1 && npm install --build-from-source=mapnik --fallback-to-build=false && npm test
+RUN . $NVM_DIR/nvm.sh && nvm use 6.11.1 && npm install --build-from-source=mapnik --fallback-to-build=false && npm test


### PR DESCRIPTION
This will make testing much more convenient (and prevent silly mistakes
like forgetting to do the run step to actually perform the mapnik build
when testing manually).