### PR TITLE
Use kartotherian fork of tilelive-tmsource to force dependency agreement

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -69,7 +69,6 @@ services:
       sources: sources.dev.yaml
 
       modules:
-      - "tilelive-tmsource"
       - "tilelive-tmstyle"
       - "@kartotherian/autogen"
       - "@kartotherian/babel"
@@ -78,6 +77,7 @@ services:
       - "@kartotherian/overzoom"
       - "@kartotherian/postgres"
       - "@kartotherian/substantial"
+      - "@kartotherian/tilelive-tmsource"
       - "@kartotherian/tilelive-vector"
       - "tilejson"
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@kartotherian/server": "^0.0.26",
     "@kartotherian/snapshot": "^0.3.12",
     "@kartotherian/substantial": "^0.0.10",
+    "@kartotherian/tilelive-tmsource": "~0.7.0",
     "@kartotherian/tilelive-vector": "^3.9.6",
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.1",
@@ -62,7 +63,6 @@
     "@mapbox/tilelive-bridge": "~2.3.1",
     "tilejson": "^1.0.3",
     "tilelive-http": "~0.13.0",
-    "tilelive-tmsource": "0.7.0",
     "tilelive-tmstyle": "0.8.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Switches tilelive-tmsource to a very light (pre-existing, but unused, now
updated) fork that pegs @mapbox/tilelive-bridge to the specific version
used by other dependencies in the tree, 2.3.1.  This unblocks the work
on migrating to the beta cluster for stretch testing, without having to
upgrade Mapnik.