### PR TITLE
Updating snapshot library

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@kartotherian/overzoom": "^0.0.16",
     "@kartotherian/postgres": "^0.0.11",
     "@kartotherian/server": "^0.0.26",
-    "@kartotherian/snapshot": "^1.0.1",
+    "@kartotherian/snapshot": "^1.0.2",
     "@kartotherian/substantial": "^0.0.10",
     "@kartotherian/tilelive-tmsource": "~1.0.0",
     "@kartotherian/tilelive-vector": "^4.0.0",


### PR DESCRIPTION
Version v1.0.1 missed one [pull request](https://github.com/kartotherian/snapshot/pull/12) that wasn't merged yet. Now v1.0.2
has the changes related to the low DPI issue.

Bug: [T152196](https://phabricator.wikimedia.org/T152196)