### PR TITLE
changing fallback ca:oc to ca:en

### DIFF
--- a/packages/babel/lib/fallbacks.json
+++ b/packages/babel/lib/fallbacks.json
@@ -31,7 +31,7 @@
     "br": "fr",
     "bug": "id",
     "bxr": "ru",
-    "ca": "oc",
+    "ca": "en",
     "cdo": [
         "nan",
         "zh-hant",


### PR DESCRIPTION
changing fallback ca:oc to ca:en according to https://ca.wikipedia.org/wiki/Tema:W1yd202mfcmqhaeo and https://phabricator.wikimedia.org/T273267